### PR TITLE
fix(client): use OnPlayerLoaded event

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -538,10 +538,9 @@ local function startPackageBlipDraw()
 end
 
 AddStateBagChangeHandler('isLoggedIn', ('player:%s'):format(cache.serverId), function(_, _, loginState)
-    if not isLoggedIn then
-        isLoggedIn = loginState
-        startPackageBlipDraw()
-    end
+    if isLoggedIn == loginState then return end
+    isLoggedIn = loginState
+    startPackageBlipDraw()
 end)
 
 CreateThread(function()

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,4 +1,5 @@
 local config = require 'config.client'
+local isLoggedIn = false
 local carryPackage = nil
 local packageCoords = nil
 local onDuty = false
@@ -523,9 +524,9 @@ RegisterNetEvent('qbx_recyclejob:client:target:dropPackage', function()
     end
 end)
 
-AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
+local function startPackageBlipDraw()
     CreateThread(function()
-        while LocalPlayer.state.isLoggedIn do
+        while isLoggedIn do
             if onDuty and packageCoords and not carryPackage and config.drawPackageLocationBlip then
                 DrawPackageLocationBlip()
                 Wait(0)
@@ -534,6 +535,11 @@ AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
             end
         end
     end)
+end
+
+AddStateBagChangeHandler('isLoggedIn', ('player:%s'):format(cache.serverId), function(_, _, loginState)
+    isLoggedIn = loginState
+    if isLoggedIn then startPackageBlipDraw() end
 end)
 
 CreateThread(function()

--- a/client/main.lua
+++ b/client/main.lua
@@ -523,19 +523,20 @@ RegisterNetEvent('qbx_recyclejob:client:target:dropPackage', function()
     end
 end)
 
--- Threads
-CreateThread(function()
-    if not LocalPlayer.state.isLoggedIn then return end
+AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
+    CreateThread(function()
+        while LocalPlayer.state.isLoggedIn do
+            if onDuty and packageCoords and not carryPackage and config.drawPackageLocationBlip then
+                DrawPackageLocationBlip()
+                Wait(0)
+            else
+                Wait(500)
+            end
+        end
+    end)
+end)
 
+CreateThread(function()
     setLocationBlip()
     registerEntranceTarget()
-
-    while true do
-        if onDuty and packageCoords and not carryPackage and config.drawPackageLocationBlip then
-            DrawPackageLocationBlip()
-            Wait(0)
-        else
-            Wait(500)
-        end
-    end
 end)

--- a/client/main.lua
+++ b/client/main.lua
@@ -538,8 +538,10 @@ local function startPackageBlipDraw()
 end
 
 AddStateBagChangeHandler('isLoggedIn', ('player:%s'):format(cache.serverId), function(_, _, loginState)
-    isLoggedIn = loginState
-    if isLoggedIn then startPackageBlipDraw() end
+    if not isLoggedIn then
+        isLoggedIn = loginState
+        startPackageBlipDraw()
+    end
 end)
 
 CreateThread(function()


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Currently this only works on restart. This moves the draw events to be triggered off the player actually loading. Breaks the blip and entrance zones into a separate thread to prevent being duplicated if a player logs out vice quitting.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
