### PR TITLE
added ox CanCarryItem checks to server/main.lua

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -1,24 +1,25 @@
 {
-    "success": {
-        "you_have_been_clocked_in": "لقد تم تسجيل دخولك"
-    },
-    "text": {
-        "point_enter_warehouse": "[E] أدخل المستودع",
-        "enter_warehouse": "أدخل المستودع",
-        "exit_warehouse": "خروج من المستودع",
-        "point_exit_warehouse": "[E] مستودع الخروج",
-        "clock_out": "تسجيل خروج",
-        "point_clock_out": "[E] - تسجيل خروج",
-        "clock_in": "تسجيل دخول",
-        "point_clock_in": "[E] - تسجيل دخول",
-        "hand_in_package": "تسليم حزمة",
-        "point_hand_in_package": "[E] تسليم حزمة",
-        "get_package": "احصل على الحزمة",
-        "point_get_package": "[E] احصل على الحزمة",
-        "picking_up_the_package": "استلام الطرد",
-        "unpacking_the_package": "تفريغ حزمة"
-    },
-    "error": {
-        "you_have_clocked_out": "لقد تم تسجيل خروج"
-    }
+  "success": {
+    "you_have_been_clocked_in": "لقد تم تسجيل دخولك"
+  },
+  "text": {
+    "point_enter_warehouse": "[E] أدخل المستودع",
+    "enter_warehouse": "أدخل المستودع",
+    "exit_warehouse": "خروج من المستودع",
+    "point_exit_warehouse": "[E] مستودع الخروج",
+    "clock_out": "تسجيل خروج",
+    "point_clock_out": "[E] - تسجيل خروج",
+    "clock_in": "تسجيل دخول",
+    "point_clock_in": "[E] - تسجيل دخول",
+    "hand_in_package": "تسليم حزمة",
+    "point_hand_in_package": "[E] تسليم حزمة",
+    "get_package": "احصل على الحزمة",
+    "point_get_package": "[E] احصل على الحزمة",
+    "picking_up_the_package": "استلام الطرد",
+    "unpacking_the_package": "تفريغ حزمة"
+  },
+  "error": {
+    "you_have_clocked_out": "لقد تم تسجيل خروج",
+    "overweight_check": "لا يمكنك حمل المزيد من العناصر"
+  }
 }

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -1,22 +1,25 @@
 {
-    "success": {
-        "you_have_been_clocked_in": "Jste přihlášeni do práce"
-    },
-    "text": {
-        "point_enter_warehouse": "[E] Vstoupit do skladiště",
-        "enter_warehouse": "Vstoupit do skladiště",
-        "exit_warehouse": "Opustit skladiště",
-        "point_exit_warehouse": "[E] Opustit skladiště",
-        "clock_out": "[E] Odhlásit se",
-        "clock_in": "[E] Přihlásit se",
-        "hand_in_package": "Odevzdat balíček",
-        "point_hand_in_package": "[E] Odevzdat balíček",
-        "get_package": "Získat balíček",
-        "point_get_package": "[E] Získat balíček",
-        "picking_up_the_package": "Zvedání balíčku",
-        "unpacking_the_package": "Rozbalování balíčku"
-    },
-    "error": {
-        "you_have_clocked_out": "Jste odhlášeni"
-    }
+  "success": {
+    "you_have_been_clocked_in": "Jste přihlášeni do práce"
+  },
+  "text": {
+    "point_enter_warehouse": "[E] Vstoupit do skladiště",
+    "enter_warehouse": "Vstoupit do skladiště",
+    "exit_warehouse": "Opustit skladiště",
+    "point_exit_warehouse": "[E] Opustit skladiště",
+    "clock_out": "[E] Odhlásit se",
+    "point_clock_out": "[E] - Odhlásit se",
+    "clock_in": "[E] Přihlásit se",
+    "point_clock_in": "[E] - Přihlásit se",
+    "hand_in_package": "Odevzdat balíček",
+    "point_hand_in_package": "[E] Odevzdat balíček",
+    "get_package": "Získat balíček",
+    "point_get_package": "[E] Získat balíček",
+    "picking_up_the_package": "Zvedání balíčku",
+    "unpacking_the_package": "Rozbalování balíčku"
+  },
+  "error": {
+    "you_have_clocked_out": "Jste odhlášeni",
+    "overweight_check": "Nemůžete nést více předmětů"
+  }
 }

--- a/locales/da.json
+++ b/locales/da.json
@@ -1,24 +1,25 @@
 {
-    "success": {
-        "you_have_been_clocked_in": "Du er blevet registreret"
-    },
-    "text": {
-        "point_enter_warehouse": "[E] - Gå ind i lageret",
-        "enter_warehouse": "Gå ind i lageret",
-        "exit_warehouse": "Forlad lageret",
-        "point_exit_warehouse": "[E] - Forlad lageret",
-        "clock_out": "Afslut arbejde",
-        "point_clock_out": "[E] - Afslut arbejde",
-        "clock_in": "Start arbejde",
-        "point_clock_in": "[E] - Start arbejde",
-        "hand_in_package": "Aflevér pakke",
-        "point_hand_in_package": "[E] - Aflevér pakke",
-        "get_package": "Hent pakke",
-        "point_get_package": "[E] - Hent pakke",
-        "picking_up_the_package": "Henter pakken",
-        "unpacking_the_package": "Pakker pakken ud"
-    },
-    "error": {
-        "you_have_clocked_out": "Du har afsluttet arbejdet"
-    }
+  "success": {
+    "you_have_been_clocked_in": "Du er blevet registreret"
+  },
+  "text": {
+    "point_enter_warehouse": "[E] - Gå ind i lageret",
+    "enter_warehouse": "Gå ind i lageret",
+    "exit_warehouse": "Forlad lageret",
+    "point_exit_warehouse": "[E] - Forlad lageret",
+    "clock_out": "Afslut arbejde",
+    "point_clock_out": "[E] - Afslut arbejde",
+    "clock_in": "Start arbejde",
+    "point_clock_in": "[E] - Start arbejde",
+    "hand_in_package": "Aflevér pakke",
+    "point_hand_in_package": "[E] - Aflevér pakke",
+    "get_package": "Hent pakke",
+    "point_get_package": "[E] - Hent pakke",
+    "picking_up_the_package": "Henter pakken",
+    "unpacking_the_package": "Pakker pakken ud"
+  },
+  "error": {
+    "you_have_clocked_out": "Du har afsluttet arbejdet",
+    "overweight_check": "Du kan ikke bære flere genstande"
+  }
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -19,6 +19,7 @@
     "unpacking_the_package": "Paket wird ausgepackt"
   },
   "error": {
-    "you_have_clocked_out": "Du hast dich ausgestempelt"
+    "you_have_clocked_out": "Du hast dich ausgestempelt",
+    "overweight_check": "Du kannst keine weiteren Gegenstände mehr tragen"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,25 +1,25 @@
 {
-    "success": {
-      "you_have_been_clocked_in": "You Have Been Clocked In"
-    },
-    "text": {
-      "point_enter_warehouse": "[E] - Enter Warehouse",
-      "enter_warehouse": "Enter Warehouse",
-      "exit_warehouse": "Exit Warehouse",
-      "point_exit_warehouse": "[E] - Exit Warehouse",
-      "clock_out": "Clock Out",
-      "point_clock_out": "[E] - Clock Out",
-      "clock_in": "Clock In",
-      "point_clock_in": "[E] - Clock In",
-      "hand_in_package": "Hand In Package",
-      "point_hand_in_package": "[E] - Hand In Package",
-      "get_package": "Get Package",
-      "point_get_package": "[E] - Get Package",
-      "picking_up_the_package": "Picking up the package",
-      "unpacking_the_package": "Unpacking the package"
-    },
-    "error": {
-      "you_have_clocked_out": "You Have Clocked Out"
-    }
+  "success": {
+    "you_have_been_clocked_in": "You Have Been Clocked In"
+  },
+  "text": {
+    "point_enter_warehouse": "[E] - Enter Warehouse",
+    "enter_warehouse": "Enter Warehouse",
+    "exit_warehouse": "Exit Warehouse",
+    "point_exit_warehouse": "[E] - Exit Warehouse",
+    "clock_out": "Clock Out",
+    "point_clock_out": "[E] - Clock Out",
+    "clock_in": "Clock In",
+    "point_clock_in": "[E] - Clock In",
+    "hand_in_package": "Hand In Package",
+    "point_hand_in_package": "[E] - Hand In Package",
+    "get_package": "Get Package",
+    "point_get_package": "[E] - Get Package",
+    "picking_up_the_package": "Picking up the package",
+    "unpacking_the_package": "Unpacking the package"
+  },
+  "error": {
+    "you_have_clocked_out": "You Have Clocked Out",
+    "overweight_check": "You Cannot Carry Anymore Items"
   }
-  
+}

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,24 +1,25 @@
 {
-    "success": {
-        "you_have_been_clocked_in": "Has registrado la entrada"
-    },
-    "text": {
-        "point_enter_warehouse": "[E] Entrar al almacén",
-        "enter_warehouse": "Entrar al almacén",
-        "exit_warehouse": "Salir del almacén",
-        "point_exit_warehouse": "[E] Salir del almacén",
-        "clock_out": "Marcar la salida",
-        "point_clock_out": "[E] - Marcar la salida",
-        "clock_in": "Marcar la entrada",
-        "point_clock_in": "[E] - Marcar la entrada",
-        "hand_in_package": "Paquete de mano",
-        "point_hand_in_package": "[E] Paquete de mano",
-        "get_package": "Obtener paquete",
-        "point_get_package": "[E] Obtener paquete",
-        "picking_up_the_package": "Recogiendo el paquete",
-        "unpacking_the_package": "Desempacando"
-    },
-    "error": {
-        "you_have_clocked_out": "Has registrado la salida"
-    }
+  "success": {
+    "you_have_been_clocked_in": "Has registrado la entrada"
+  },
+  "text": {
+    "point_enter_warehouse": "[E] Entrar al almacén",
+    "enter_warehouse": "Entrar al almacén",
+    "exit_warehouse": "Salir del almacén",
+    "point_exit_warehouse": "[E] Salir del almacén",
+    "clock_out": "Marcar la salida",
+    "point_clock_out": "[E] - Marcar la salida",
+    "clock_in": "Marcar la entrada",
+    "point_clock_in": "[E] - Marcar la entrada",
+    "hand_in_package": "Paquete de mano",
+    "point_hand_in_package": "[E] Paquete de mano",
+    "get_package": "Obtener paquete",
+    "point_get_package": "[E] Obtener paquete",
+    "picking_up_the_package": "Recogiendo el paquete",
+    "unpacking_the_package": "Desempacando"
+  },
+  "error": {
+    "you_have_clocked_out": "Has registrado la salida",
+    "overweight_check": "No puedes llevar más objetos"
+  }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,24 +1,25 @@
 {
-    "success": {
-        "you_have_been_clocked_in": "Vous avez pris votre service"
-    },
-    "text": {
-        "point_enter_warehouse": "[E] Entrer dans l'entrepôt",
-        "enter_warehouse": "Entrer dans l'entrepôt",
-        "exit_warehouse": "Sortir de l'entrepôt",
-        "point_exit_warehouse": "[E] Sortir de l'entrepôt",
-        "clock_out": "Quitter son service",
-        "point_clock_out": "[E] - Quitter son service",
-        "clock_in": "Prendre son service",
-        "point_clock_in": "[E] - Prendre son service",
-        "hand_in_package": "Donner la boite",
-        "point_hand_in_package": "[E] Donner la boite",
-        "get_package": "Prendre une boite",
-        "point_get_package": "[E] Prendre une boite",
-        "picking_up_the_package": "Prend une boite..",
-        "unpacking_the_package": "Déballe la boite.."
-    },
-    "error": {
-        "you_have_clocked_out": "Vous avez quitté votre service!"
-    }
+  "success": {
+    "you_have_been_clocked_in": "Vous avez pointé"
+  },
+  "text": {
+    "point_enter_warehouse": "[E] - Entrer dans l'entrepôt",
+    "enter_warehouse": "Entrer dans l'entrepôt",
+    "exit_warehouse": "Sortir de l'entrepôt",
+    "point_exit_warehouse": "[E] Sortir de l'entrepôt",
+    "clock_out": "Quitter son service",
+    "point_clock_out": "[E] - Quitter son service",
+    "clock_in": "Prendre son service",
+    "point_clock_in": "[E] - Prendre son service",
+    "hand_in_package": "Donner la boite",
+    "point_hand_in_package": "[E] Donner la boite",
+    "get_package": "Prendre une boite",
+    "point_get_package": "[E] Prendre une boite",
+    "picking_up_the_package": "Prend une boite..",
+    "unpacking_the_package": "Déballe la boite.."
+  },
+  "error": {
+    "you_have_clocked_out": "Vous avez quitté votre service!",
+    "overweight_check": "Vous ne pouvez plus porter d'objets"
+  }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -1,25 +1,25 @@
 {
-    "success": {
-      "you_have_been_clocked_in": "Je bent ingeklokt"
-    },
-    "text": {
-      "point_exit_warehouse": "[E] Verlaat magazijn",
-      "point_enter_warehouse": "[E] Betreed magazijn",
-      "enter_warehouse": "Betreed magazijn",
-      "exit_warehouse": "Verlaat magazijn",
-      "clock_in": "Klok in",
-      "point_clock_in": "[E] - Klok in",
-      "clock_out": "Klok uit",
-      "point_clock_out": "[E] - Klok uit",
-      "point_hand_in_package": "[E] Pakket inleveren",
-      "hand_in_package": "Pakket inleveren",
-      "point_get_package": "[E] Pak pakket",
-      "get_package": "Pak pakket",
-      "picking_up_the_package": "Pakket oppakken",
-      "unpacking_the_package": "Pakket uitpakken"
-    },
-    "error": {
-      "you_have_clocked_out": "Je bent uitgeklokt"
-    }
+  "success": {
+    "you_have_been_clocked_in": "Je bent ingeklokt"
+  },
+  "text": {
+    "point_exit_warehouse": "[E] Verlaat magazijn",
+    "point_enter_warehouse": "[E] Betreed magazijn",
+    "enter_warehouse": "Betreed magazijn",
+    "exit_warehouse": "Verlaat magazijn",
+    "clock_in": "Klok in",
+    "point_clock_in": "[E] - Klok in",
+    "clock_out": "Klok uit",
+    "point_clock_out": "[E] - Klok uit",
+    "point_hand_in_package": "[E] Pakket inleveren",
+    "hand_in_package": "Pakket inleveren",
+    "point_get_package": "[E] Pak pakket",
+    "get_package": "Pak pakket",
+    "picking_up_the_package": "Pakket oppakken",
+    "unpacking_the_package": "Pakket uitpakken"
+  },
+  "error": {
+    "you_have_clocked_out": "Je bent uitgeklokt",
+    "overweight_check": "Je kunt geen items meer dragen"
   }
-  
+}

--- a/locales/pt-br.json
+++ b/locales/pt-br.json
@@ -1,25 +1,25 @@
 {
-    "success": {
-        "you_have_been_clocked_in": "Você foi registrado como presente"
-    },
-    "text": {
-        "point_enter_warehouse": "[E] - Entrar no Armazém",
-        "enter_warehouse": "Entrar no Armazém",
-        "exit_warehouse": "Sair do Armazém",
-        "point_exit_warehouse": "[E] - Sair do Armazém",
-        "clock_out": "Registrar Saída",
-        "point_clock_out": "[E] - Registrar Saída",
-        "clock_in": "Registrar Entrada",
-        "point_clock_in": "[E] - Registrar Entrada",
-        "hand_in_package": "Entregar Pacote",
-        "point_hand_in_package": "[E] - Entregar Pacote",
-        "get_package": "Pegar Pacote",
-        "point_get_package": "[E] - Pegar Pacote",
-        "picking_up_the_package": "Pegando o pacote",
-        "unpacking_the_package": "Desempacotando o pacote"
-    },
-    "error": {
-        "you_have_clocked_out": "Você se registrou como ausente"
-    }
+  "success": {
+    "you_have_been_clocked_in": "Você foi registrado como presente"
+  },
+  "text": {
+    "point_enter_warehouse": "[E] - Entrar no Armazém",
+    "enter_warehouse": "Entrar no Armazém",
+    "exit_warehouse": "Sair do Armazém",
+    "point_exit_warehouse": "[E] - Sair do Armazém",
+    "clock_out": "Registrar Saída",
+    "point_clock_out": "[E] - Registrar Saída",
+    "clock_in": "Registrar Entrada",
+    "point_clock_in": "[E] - Registrar Entrada",
+    "hand_in_package": "Entregar Pacote",
+    "point_hand_in_package": "[E] - Entregar Pacote",
+    "get_package": "Pegar Pacote",
+    "point_get_package": "[E] - Pegar Pacote",
+    "picking_up_the_package": "Pegando o pacote",
+    "unpacking_the_package": "Desempacotando o pacote"
+  },
+  "error": {
+    "you_have_clocked_out": "Você se registrou como ausente",
+    "overweight_check": "Você não pode carregar mais itens"
+  }
 }
-  

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -1,24 +1,25 @@
 {
   "success": {
-      "you_have_been_clocked_in": "Estás agora de serviço"
+    "you_have_been_clocked_in": "Estás agora de serviço"
   },
   "text": {
-      "point_enter_warehouse": "[E] - Entrar no Armazém",
-      "enter_warehouse": "Entrar no Armazém",
-      "exit_warehouse": "Sair do Armazém",
-      "point_exit_warehouse": "[E] - Sair do Armazém",
-      "clock_out": "Sair de Serviço",
-      "point_clock_out": "[E] - Sair de Serviço",
-      "clock_in": "Entrar de Serviço",
-      "point_clock_in": "[E] - Entrar de Serviço",
-      "hand_in_package": "Entregar Pacote",
-      "point_hand_in_package": "[E] - Entregar Pacote",
-      "get_package": "Pegar Pacote",
-      "point_get_package": "[E] - Pegar Pacote",
-      "picking_up_the_package": "A pegar o pacote",
-      "unpacking_the_package": "A desempacotar o pacote"
+    "point_enter_warehouse": "[E] - Entrar no Armazém",
+    "enter_warehouse": "Entrar no Armazém",
+    "exit_warehouse": "Sair do Armazém",
+    "point_exit_warehouse": "[E] - Sair do Armazém",
+    "clock_out": "Sair de Serviço",
+    "point_clock_out": "[E] - Sair de Serviço",
+    "clock_in": "Entrar de Serviço",
+    "point_clock_in": "[E] - Entrar de Serviço",
+    "hand_in_package": "Entregar Pacote",
+    "point_hand_in_package": "[E] - Entregar Pacote",
+    "get_package": "Pegar Pacote",
+    "point_get_package": "[E] - Pegar Pacote",
+    "picking_up_the_package": "A pegar o pacote",
+    "unpacking_the_package": "A desempacotar o pacote"
   },
   "error": {
-      "you_have_clocked_out": "Saíste de Serviço"
+    "you_have_clocked_out": "Saíste de Serviço",
+    "overweight_check": "Você não pode carregar mais itens"
   }
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -6,19 +6,31 @@ RegisterNetEvent('qbx_recycle:server:getItem', function()
     for _ = 1, math.random(1, config.maxItemsReceived), 1 do
         local randItem = config.itemTable[math.random(1, #config.itemTable)]
         local amount = math.random(config.minItemReceivedQty, config.maxItemReceivedQty)
-        exports.ox_inventory:AddItem(src, randItem, amount)
-        Wait(500)
+        if exports.ox_inventory:CanCarryItem(src, randItem, amount) then
+            exports.ox_inventory:AddItem(src, randItem, amount)
+            Wait(500)
+        else
+            exports.qbx_core:Notify(source, locale('overweight_check'), 'error')
+        end
     end
 
     local chance = math.random(1, 100)
     if chance < 7 then
-        exports.ox_inventory:AddItem(src, config.chanceItem, 1)
+        if exports.ox_inventory:CanCarryItem(src, config.chanceItem, 1) then
+            exports.ox_inventory:AddItem(src, config.chanceItem, 1)
+        else
+            exports.qbx_core:Notify(source, locale('overweight_check'), 'error')
+        end
     end
 
     local luck = math.random(1, 10)
     local odd = math.random(1, 10)
     if luck == odd then
         local random = math.random(1, 3)
-        exports.ox_inventory:AddItem(src, config.luckyItem, random)
+        if exports.ox_inventory:CanCarryItem(src, config.luckyItem, random) then
+            exports.ox_inventory:AddItem(src, config.luckyItem, random)
+        else
+            exports.qbx_core:Notify(source, locale('overweight_check'), 'error')
+        end
     end
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -10,7 +10,7 @@ RegisterNetEvent('qbx_recycle:server:getItem', function()
             exports.ox_inventory:AddItem(src, randItem, amount)
             Wait(500)
         else
-            exports.qbx_core:Notify(source, locale('overweight_check'), 'error')
+            exports.qbx_core:Notify(source, locale('error.overweight_check'), 'error')
         end
     end
 
@@ -19,7 +19,7 @@ RegisterNetEvent('qbx_recycle:server:getItem', function()
         if exports.ox_inventory:CanCarryItem(src, config.chanceItem, 1) then
             exports.ox_inventory:AddItem(src, config.chanceItem, 1)
         else
-            exports.qbx_core:Notify(source, locale('overweight_check'), 'error')
+            exports.qbx_core:Notify(source, locale('error.overweight_check'), 'error')
         end
     end
 
@@ -30,7 +30,7 @@ RegisterNetEvent('qbx_recycle:server:getItem', function()
         if exports.ox_inventory:CanCarryItem(src, config.luckyItem, random) then
             exports.ox_inventory:AddItem(src, config.luckyItem, random)
         else
-            exports.qbx_core:Notify(source, locale('overweight_check'), 'error')
+            exports.qbx_core:Notify(source, locale('error.overweight_check'), 'error')
         end
     end
 end)


### PR DESCRIPTION
added the proper ox inventory checks for the can carry item to the add items exports.

## Description

This will edit the code so players cant load their inventory and make themselves overweight by collecting base materials from the recycle center job. This adds the necessary ox_inventory code to block abuse of this script.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x ] My pull request fits the contribution guidelines & code conventions.