### PR TITLE
Added Locales for Item check notify in en.json

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -19,7 +19,8 @@
       "unpacking_the_package": "Unpacking the package"
     },
     "error": {
-      "you_have_clocked_out": "You Have Clocked Out"
+      "you_have_clocked_out": "You Have Clocked Out",
+      "overweight_check": "You Cannot Carry Anymore Items"
     }
   }
   


### PR DESCRIPTION
Added the item check locales for English only

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
This is just the locales for the en.json file to adhere to the changes made to the server/main.lua where the ox_inventory CanCarryItem checks were placed.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x ] My pull request fits the contribution guidelines & code conventions.
