### PR TITLE
Fix: replace 'source' with 'src' in notification logic

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -10,7 +10,7 @@ RegisterNetEvent('qbx_recycle:server:getItem', function()
             exports.ox_inventory:AddItem(src, randItem, amount)
             Wait(500)
         else
-            exports.qbx_core:Notify(source, locale('error.overweight_check'), 'error')
+            exports.qbx_core:Notify(src, locale('error.overweight_check'), 'error')
         end
     end
 
@@ -19,7 +19,7 @@ RegisterNetEvent('qbx_recycle:server:getItem', function()
         if exports.ox_inventory:CanCarryItem(src, config.chanceItem, 1) then
             exports.ox_inventory:AddItem(src, config.chanceItem, 1)
         else
-            exports.qbx_core:Notify(source, locale('error.overweight_check'), 'error')
+            exports.qbx_core:Notify(src, locale('error.overweight_check'), 'error')
         end
     end
 
@@ -30,7 +30,7 @@ RegisterNetEvent('qbx_recycle:server:getItem', function()
         if exports.ox_inventory:CanCarryItem(src, config.luckyItem, random) then
             exports.ox_inventory:AddItem(src, config.luckyItem, random)
         else
-            exports.qbx_core:Notify(source, locale('error.overweight_check'), 'error')
+            exports.qbx_core:Notify(src, locale('error.overweight_check'), 'error')
         end
     end
 end)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Fixes some cases where source is undefined.
```
[    c-scripting-core] script error in native 000000002f7a49e6: Argument at index 1 was null.
[     script:qbx_core] SCRIPT ERROR: native 000000002f7a49e6: Argument at index 1 was null.
[     script:qbx_core] > ref (@qbx_core/server/functions.lua:414)
[     script:qbx_core] > handler (@qbx_recyclejob/server/main.lua:13)
[script:qbx_recyclejo] SCRIPT ERROR: @qbx_recyclejob/server/main.lua:13: 
[script:qbx_recyclejo]  An error occurred while calling export `Notify` in resource `qbx_core`:
[script:qbx_recyclejo]   nil
[script:qbx_recyclejo]  ---
```

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
