### PR TITLE
fix: make recycle rewards server authoritative

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -288,8 +288,8 @@ local function scrapAnim()
     end)
 end
 
-local function getRandomPackage()
-    packageCoords = config.pickupLocations[math.random(1, #config.pickupLocations)]
+local function getNextPackage(coords)
+    packageCoords = coords
     RegisterPickupTarget(packageCoords)
 end
 
@@ -444,9 +444,15 @@ RegisterNetEvent('qbx_recyclejob:client:target:toggleDuty', function()
     onDuty = not onDuty
 
     if onDuty then
+        local nextPackage = lib.callback.await('qbx_recyclejob:server:startShift', false)
+        if not nextPackage then
+            onDuty = false
+            return
+        end
         exports.qbx_core:Notify(locale("success.you_have_been_clocked_in"), 'success')
-        getRandomPackage()
+        getNextPackage(nextPackage)
     else
+        TriggerServerEvent('qbx_recyclejob:server:endShift')
         exports.qbx_core:Notify(locale("error.you_have_clocked_out"), 'error')
         destroyPickupTarget()
     end
@@ -478,6 +484,7 @@ RegisterNetEvent('qbx_recyclejob:client:target:pickupPackage', function()
             combat = true
         },
     }) then
+        if not lib.callback.await('qbx_recyclejob:server:pickupPackage', false) then return end
         packageCoords = nil
         StopAnimTask(cache.ped, 'mp_car_bomb', 'car_bomb_mechanic', 1.0)
         ClearPedTasks(cache.ped)
@@ -511,8 +518,8 @@ RegisterNetEvent('qbx_recyclejob:client:target:dropPackage', function()
         },
     }) then
         StopAnimTask(cache.ped, 'mp_car_bomb', 'car_bomb_mechanic', 1.0)
-        TriggerServerEvent('qbx_recycle:server:getItem')
-        getRandomPackage()
+        local nextPackage = lib.callback.await('qbx_recyclejob:server:deliverPackage', false)
+        if nextPackage then getNextPackage(nextPackage) end
     else
         exports.qbx_core:Notify(locale('error.canceled'), 'error')
     end

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,7 +1,17 @@
 local config = require 'config.server'
+local clientConfig = require 'config.client'
+local workSessions = {}
 
-RegisterNetEvent('qbx_recycle:server:getItem', function()
-    local src = source
+---@param source number
+---@param coords vector3
+---@param maxDistance number
+---@return boolean
+local function isNear(source, coords, maxDistance)
+    return #(GetEntityCoords(GetPlayerPed(source)) - coords) <= maxDistance
+end
+
+---@param src number
+local function giveRewards(src)
 
     for _ = 1, math.random(1, config.maxItemsReceived), 1 do
         local randItem = config.itemTable[math.random(1, #config.itemTable)]
@@ -33,4 +43,49 @@ RegisterNetEvent('qbx_recycle:server:getItem', function()
             exports.qbx_core:Notify(src, locale('error.overweight_check'), 'error')
         end
     end
+end
+
+lib.callback.register('qbx_recyclejob:server:startShift', function(source)
+    if not isNear(source, clientConfig.dutyLocation.xyz, 3.0) then return end
+
+    local pickupIndex = math.random(1, #clientConfig.pickupLocations)
+    workSessions[source] = { pickupIndex = pickupIndex, carrying = false }
+    return clientConfig.pickupLocations[pickupIndex]
+end)
+
+lib.callback.register('qbx_recyclejob:server:pickupPackage', function(source)
+    local session = workSessions[source]
+    if not session or session.carrying then return false end
+
+    local pickupCoords = clientConfig.pickupLocations[session.pickupIndex]
+    if not pickupCoords or not isNear(source, pickupCoords.xyz, 3.0) then return false end
+
+    session.carrying = true
+    session.pickupTime = os.time()
+    return true
+end)
+
+lib.callback.register('qbx_recyclejob:server:deliverPackage', function(source)
+    local session = workSessions[source]
+    local minimumDeliveryTime = math.max(1, math.floor(clientConfig.deliveryActionDuration / 1000))
+    if not session or not session.carrying or not session.pickupTime
+        or os.time() - session.pickupTime < minimumDeliveryTime
+        or not isNear(source, clientConfig.dropLocation.xyz, 3.0)
+    then
+        return
+    end
+
+    giveRewards(source)
+    session.pickupIndex = math.random(1, #clientConfig.pickupLocations)
+    session.carrying = false
+    session.pickupTime = nil
+    return clientConfig.pickupLocations[session.pickupIndex]
+end)
+
+RegisterNetEvent('qbx_recyclejob:server:endShift', function()
+    workSessions[source] = nil
+end)
+
+AddEventHandler('playerDropped', function()
+    workSessions[source] = nil
 end)


### PR DESCRIPTION
Replaces the unrestricted reward event with server-owned shifts, assigned pickups, proximity checks, and timed package transitions. Validation: git diff --check.